### PR TITLE
fix issue of the extension no longer working after screen lock and then unlock is done.

### DIFF
--- a/start-overlay-in-application-view@cis.net/extension.js
+++ b/start-overlay-in-application-view@cis.net/extension.js
@@ -22,7 +22,7 @@ function init() {
 function enable() {
 
     // save the existing toggle function so we can use to to restore bits later
-    nativeToggleFunction = Overview.Overview.prototype['toggle'];
+    originalToggleFunction = Overview.Overview.prototype['toggle'];
 
     /*
     this is a copy of an existing toggle function but where we
@@ -78,8 +78,9 @@ function enable() {
 function disable() {
 
     /* 
-    if have the original function, put it back to back and re-bind the
-    'panel-main-menu' to original toggle again. (See explanation in enable function)
+    if we have the original function, put it back to back and re-bind the
+    'panel-main-menu' to original toggle again. (See explanation in enable
+    function)
     */
     if (originalToggleFunction !== null) {
         // save the ogi

--- a/start-overlay-in-application-view@cis.net/extension.js
+++ b/start-overlay-in-application-view@cis.net/extension.js
@@ -1,27 +1,96 @@
 
-const overview = imports.ui.overview;
+// ......................................................................... //
+// imports
+const Main = imports.ui.main;
+const Shell = imports.gi.Shell;
+const Overview = imports.ui.overview;
 
-let origin;
+// ......................................................................... //
+// extension scoped variable used to hold the original toggle function so we
+// can assign it back on extension disable step
+let originalToggleFunction;
 
+
+// ......................................................................... //
 function init() {
-    origin = null;
+    // on intialization set the our original toggle holding variable to null
+    originalToggleFunction = null;
 }
 
+
+// ......................................................................... //
 function enable() {
-    origin = overview.Overview.prototype['toggle'];
-    overview.Overview.prototype['toggle'] = function() {
-        if (this.isDummy)
-            return;
 
-        if (this.visible)
-            this.hide();
-        else
-            this.viewSelector.showApps();
-    };
+    // save the existing toggle function so we can use to to restore bits later
+    nativeToggleFunction = Overview.Overview.prototype['toggle'];
+
+    /*
+    this is a copy of an existing toggle function but where we
+    show apps but hid the whole Overview.
+    TODO: currently we do not trigger animation so if the Overview is
+          toggled before the icons appear (can be toggled by other apps like
+          dash-to-dock) so if the hiding the Overview happens before animation
+          is complete or the next application shows only some apps (ones that)
+          were drawn before untoggling wil appear. So we either need to run
+          the animation or if we do not use it we do the same tricks 
+          dash-to-dock does where it hides the Overview, does speedy animation
+          and unhides. We need to look into "_animateVisible"
+    */
+    Overview.Overview.prototype['toggle'] = 
+        function startOverlayInApplicationViewToggle() {
+            if (this.isDummy) {
+                return;
+            }
+
+            if (this.visible) {
+                this.hide();
+            }
+            else {
+                this.viewSelector.showApps();
+            }
+        };
+
+    /*
+    "re"-bind 'panel-main-menu' to our monkeypatched function needed because 
+    of race conditions. Specifically during the login or Gnome Shell
+    restart extension is enabled before the keybind is bound to the function by
+    a call from "_sessionUpdated" function in main.js all works well. 
+
+    However, when Gnome Shell Screen Lock is activated it disables the 
+    extension as part of the normal process hence unpatching the toggle
+    prototype back to the original function. Then when the Screen Lock is
+    deactivated it looks like _sessionUpdated is run before extension enabled
+    and monkeypatching happens after it hence not binding out toggle function.
+
+    So we manually bind it ourselves.
+    */
+    Main.wm.setCustomKeybindingHandler(
+        'panel-main-menu',
+        Shell.ActionMode.NORMAL |
+        Shell.ActionMode.OVERVIEW,
+        Main.sessionMode.hasOverview ? 
+            Main.overview.toggle.bind(Main.overview) : null
+    );
 }
 
+
+// ......................................................................... //
 function disable() {
-    if (origin) {
-        overview.Overview.prototype['toggle'] = origin;
+
+    /* 
+    if have the original function, put it back to back and re-bind the
+    'panel-main-menu' to original toggle again. (See explanation in enable function)
+    */
+    if (originalToggleFunction !== null) {
+        // save the ogi
+        Overview.Overview.prototype['toggle'] = originalToggleFunction;
+        // "re"-bind 'panel-main-menu' to our monkeypatched function 
+        Main.wm.setCustomKeybindingHandler(
+            'panel-main-menu',
+            Shell.ActionMode.NORMAL |
+            Shell.ActionMode.OVERVIEW,
+            Main.sessionMode.hasOverview ? 
+                Main.overview.toggle.bind(Main.overview) : null
+      );
     }
 }

--- a/start-overlay-in-application-view@cis.net/metadata.json
+++ b/start-overlay-in-application-view@cis.net/metadata.json
@@ -1,8 +1,15 @@
 {
   "uuid": "start-overlay-in-application-view@cis.net",
   "name": "Start Overlay in Application View",
-  "description": "When pressing the Super key, the application view is shown instead of the view with the windows.",
+  "description": "When pressing activating overview, the application view is shown instead of the view with the windows.",
   "shell-version": [
-    "3.18"
-  ]
+    "3.18",
+    "3.20",
+    "3.22",
+    "3.24",
+    "3.26",
+    "3.28"
+  ],
+  "version": 2
 }
+

--- a/start-overlay-in-application-view@cis.net/metadata.json
+++ b/start-overlay-in-application-view@cis.net/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "start-overlay-in-application-view@cis.net",
   "name": "Start Overlay in Application View",
-  "description": "When pressing activating overview, the application view is shown instead of the view with the windows.",
+  "description": "When activating overview, the application view is shown instead of the view with the windows.",
   "shell-version": [
     "3.18",
     "3.20",


### PR DESCRIPTION
Hi,

Like your extension it does a good job. However, it stops working after screen lock and unlock is done. I tracked down the issue and fixed it. I included comments in the code to explain the issue. Also I renamed variables to be a tad more readable.

I am hoping you can merge the code in and post the updated extension.

As a note your extension and the one by fawtytoo (https://extensions.gnome.org/extension/1337/show-applications-instead-of-overview/) have nearly the same code, however I could not find his in any place I can submit a PR to. And it seems silly to create yet a third extension.

Let me know if you have any questions.